### PR TITLE
Keep idle state in store and use actions to change idle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,45 @@
 [![NPM Version](https://img.shields.io/npm/v/redux-promises.svg?style=flat)](https://npmjs.org/package/redux-promises)
 [![Build Status](https://img.shields.io/travis/CrocoDillon/redux-promises.svg?style=flat)](https://travis-ci.org/CrocoDillon/redux-promises)
 
-Promise based middleware for Redux to deal with asynchronous actions. `redux-promises` is backwards compatible with [`redux-thunk`](https://github.com/gaearon/redux-thunk). It works by collecting any promise returned by action thunks, to keep track whether or not these promises are pending or not.
+Promise based middleware for Redux to deal with asynchronous actions. `redux-promises` is backwards compatible with [`redux-thunk`](https://github.com/gaearon/redux-thunk).
+
+It works by collecting any promise returned by action thunks, to keep track whether or not these promises are pending or not. When there are no pending promises the state is idle.
+
+## Installation
 
 ```bash
 npm install --save redux-promises
+```
+
+You need to use the `redux-promises` middleware and reducer.
+
+```javascript
+import { combineReducers, applyMiddleware, createStore } from 'redux';
+import { reducer as idleReducer, createMiddleware } from 'redux-promises';
+
+const reducer = combineReducers({
+  idle: idleReducer,
+  // ...other reducers
+});
+
+const promisesMiddleware = createMiddleware();
+const store = applyMiddleware(promisesMiddleware)(createStore)(reducer);
+```
+
+You can then call the function `ensureIdleState` which returns a promise that resolves as soon as there are no more pending promises and the state is idle.
+
+```javascript
+import { ensureIdleState } from 'redux-promises';
+
+ensureIdleState(store).then(() => {
+  // do awesome stuff knowing all promises (if any) are resolved (or rejected)
+});
+```
+
+If you don’t want to store `redux-promises` state under the `idle` key, you need to pass a function to select state to `ensureIdleState`.
+
+```javascript
+ensureIdleState(store, state => state.myIdleKey).then(() => {/**/});
 ```
 
 ## Why?
@@ -19,10 +54,10 @@ A simple example, working code can be found in the `examples/simple` directory.
 
 ```javascript
 import { createStore, applyMiddleware } from 'redux';
-import promises from 'redux-promises';
-import reducers from './reducers';
+import { createMiddleware, ensureIdleState } from 'redux-promises';
+import reducers from './reducers'; // should include `redux-promises` reducer
 
-const promisesMiddleware = promises();
+const promisesMiddleware = createMiddleware();
 const store = applyMiddleware(promisesMiddleware)(createStore)(reducers);
 
 // Action creator that returns a thunk that returns a promise
@@ -40,7 +75,7 @@ store.dispatch(fetchData('http://api.example.com/some/resouce'));
 store.dispatch(fetchData('http://api.example.com/another/resouce'));
 
 // Now we wait till all required data has been fetched
-promisesMiddleware.then(() => {
+ensureIdleState(store).then(() => {
   // Fetching all data complete
 });
 ```

--- a/examples/thunk-creator/index.js
+++ b/examples/thunk-creator/index.js
@@ -1,17 +1,22 @@
-import { createStore, applyMiddleware } from 'redux';
-import promises from '../../src';
+import { combineReducers, applyMiddleware, createStore } from 'redux';
+import { reducer as idleReducer, createMiddleware, ensureIdleState } from '../../src';
 import thunkCreator from './thunkCreator';
 import fetch from './fetch';
 
 // Reducer that just logs time since start and action object
 const startTime = Date.now();
-const reducer = (state, action) => {
+const logReducer = (state = null, action) => {
   console.log(`Dispatch after ${Date.now() - startTime}ms`)
   console.log(JSON.stringify(action, null, 2));
   return state;
 };
 
-const promisesMiddleware = promises();
+const reducer = combineReducers({
+  idle: idleReducer,
+  log: logReducer
+});
+
+const promisesMiddleware = createMiddleware();
 const store = applyMiddleware(promisesMiddleware)(createStore)(reducer);
 
 // Action creator that returns a thunk that returns a promise
@@ -25,6 +30,6 @@ store.dispatch(fetchData('http://api.example.com/some/resouce'));
 store.dispatch(fetchData('http://api.example.com/another/resouce'));
 
 // Now we wait till all required data has been fetched
-promisesMiddleware.then(() => {
+ensureIdleState(store).then(() => {
   console.log(`Fetching all data complete after ${Date.now() - startTime}ms`);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ const reducer = (state = true, action) => {
   switch (action.type) {
   case CHANGE_IDLE_STATE:
     return action.state;
-    break;
   }
   return state;
 };
@@ -28,9 +27,9 @@ const createMiddleware = () => {
   const middleware = ({ dispatch, getState }) => {
     return (next) => (action) => {
       if (typeof action === 'function') {
-        let promise = action(dispatch, getState);
-        if (isPromise(promise)) {
-          promise = promise.then(noop, noop);
+        const maybePromise = action(dispatch, getState);
+        if (isPromise(maybePromise)) {
+          const promise = maybePromise.then(noop, noop);
           promise.then(() => {
             promises = promises.filter((p) => (p !== promise));
             if (promises.length === 0) {
@@ -40,7 +39,7 @@ const createMiddleware = () => {
           promises.push(promise);
           dispatch(changeIdleState(false));
         }
-        return promise;
+        return maybePromise;
       } else {
         return next(action);
       }
@@ -71,4 +70,5 @@ const ensureIdleState = (store, selectState = SELECT_STATE) => {
     });
   });
 };
+
 export { reducer, createMiddleware, ensureIdleState };

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
-import promises from '../src/index';
+import { createMiddleware } from '../src/index';
 
-const promisesMiddleware = promises();
+const promisesMiddleware = createMiddleware();
 
 // Ensure backwards compatibility with redux-thunk
 // https://github.com/gaearon/redux-thunk

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,10 @@ const config = {
     ]
   },
   plugins: [
-    new webpack.optimize.OccurenceOrderPlugin()
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
+    })
   ],
   devtool: 'source-map'
 };


### PR DESCRIPTION
This results in a better API. You no longer need a reference to the middleware when you want to query for a promise, you just need the store.

Also means idle state is stored in the store.

``` javascript
import { reducer as idleReducer, createMiddleware, ensureIdleState } from 'redux-promises';

const reducer = combineReducers({
  idle: idleReducer,
  // other reducers
});
const promisesMiddleware = createMiddleware();
const store = applyMiddleware(promisesMiddleware)(createStore)(reducer);

// dispatch some async actions

ensureIdleState(store).then(() => {
  // everything resolved (or rejected)
});
```
